### PR TITLE
rename TOKEN_MERGE to TOKEN_UPDATE

### DIFF
--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -37,7 +37,7 @@ pub enum SyntaxKind {
     TOKEN_PAREN_CLOSE,
     TOKEN_CONCAT,
     TOKEN_INVERT,
-    TOKEN_MERGE,
+    TOKEN_UPDATE,
 
     TOKEN_ADD,
     TOKEN_SUB,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -28,7 +28,7 @@ macro_rules! T {
     (;)       => ($crate::SyntaxKind::TOKEN_SEMICOLON);
     (++)      => ($crate::SyntaxKind::TOKEN_CONCAT);
     (!)       => ($crate::SyntaxKind::TOKEN_INVERT);
-    ("//")    => ($crate::SyntaxKind::TOKEN_MERGE);
+    ("//")    => ($crate::SyntaxKind::TOKEN_UPDATE);
 
     (+)       => ($crate::SyntaxKind::TOKEN_ADD);
     (-)       => ($crate::SyntaxKind::TOKEN_SUB);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -539,7 +539,7 @@ where
         }
     }
     fn parse_merge(&mut self) -> Checkpoint {
-        self.handle_operation(false, Self::parse_invert, &[TOKEN_MERGE])
+        self.handle_operation(false, Self::parse_invert, &[TOKEN_UPDATE])
     }
     fn parse_compare(&mut self) -> Checkpoint {
         self.handle_operation(

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -322,7 +322,7 @@ impl<'a> Iterator for Tokenizer<'a> {
             }
             '/' if self.peek() == Some('/') => {
                 self.next().unwrap();
-                Some((TOKEN_MERGE, self.string_since(start)))
+                Some((TOKEN_UPDATE, self.string_since(start)))
             }
             '+' => Some((TOKEN_ADD, self.string_since(start))),
             '-' => Some((TOKEN_SUB, self.string_since(start))),
@@ -884,7 +884,7 @@ mod tests {
     fn combine() {
         assert_eq!(
             tokenize("a//b"),
-            tokens![(TOKEN_IDENT, "a"), (TOKEN_MERGE, "//"), (TOKEN_IDENT, "b")]
+            tokens![(TOKEN_IDENT, "a"), (TOKEN_UPDATE, "//"), (TOKEN_IDENT, "b")]
         );
     }
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -238,7 +238,7 @@ impl<'a> Iterator for Tokenizer<'a> {
                 _ => false,
             });
             match (lookahead.next(), lookahead.next()) {
-                // a//b parses as Merge(a, b)
+                // a//b parses as Update(a, b)
                 (Some('/'), Some('/')) => None,
                 (Some('/'), Some('*')) => None,
                 (Some('/'), Some(c)) if !c.is_whitespace() => Some(IdentType::Path),

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,7 +68,7 @@ impl OpKind {
         match token {
             TOKEN_CONCAT => Some(OpKind::Concat),
             TOKEN_QUESTION => Some(OpKind::IsSet),
-            TOKEN_MERGE => Some(OpKind::Merge),
+            TOKEN_UPDATE => Some(OpKind::Merge),
 
             TOKEN_ADD => Some(OpKind::Add),
             TOKEN_SUB => Some(OpKind::Sub),

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,7 @@ macro_rules! nth {
 pub enum OpKind {
     Concat,
     IsSet,
-    Merge,
+    Update,
 
     Add,
     Sub,
@@ -68,7 +68,7 @@ impl OpKind {
         match token {
             TOKEN_CONCAT => Some(OpKind::Concat),
             TOKEN_QUESTION => Some(OpKind::IsSet),
-            TOKEN_UPDATE => Some(OpKind::Merge),
+            TOKEN_UPDATE => Some(OpKind::Update),
 
             TOKEN_ADD => Some(OpKind::Add),
             TOKEN_SUB => Some(OpKind::Sub),

--- a/test_data/parser/merge/1.expect
+++ b/test_data/parser/merge/1.expect
@@ -16,7 +16,7 @@ NODE_ROOT 0..14 {
       }
       TOKEN_CURLY_B_CLOSE("}") 5..6
     }
-    TOKEN_MERGE("//") 6..8
+    TOKEN_UPDATE("//") 6..8
     NODE_SET 8..14 {
       TOKEN_CURLY_B_OPEN("{") 8..9
       NODE_SET_ENTRY 9..13 {


### PR DESCRIPTION
according to src/libexpr/lexer.l, nix calls `//` the UPDATE token

see https://github.com/nixos/nix/blob/f435634a29551754d5f7303b0a60cd8fe2df2079/src/libexpr/lexer.l#L122