### PR TITLE
rename index_set to select

### DIFF
--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -75,7 +75,7 @@ pub enum SyntaxKind {
     NODE_ERROR,
     NODE_IDENT,
     NODE_IF_ELSE,
-    NODE_INDEX_SET,
+    NODE_SELECT,
     NODE_INHERIT,
     NODE_INHERIT_FROM,
     NODE_STRING,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -461,7 +461,7 @@ where
         };
 
         while self.peek() == Some(TOKEN_DOT) {
-            self.start_node_at(checkpoint, NODE_INDEX_SET);
+            self.start_node_at(checkpoint, NODE_SELECT);
             self.bump();
             self.next_attr();
             self.finish_node();

--- a/src/types.rs
+++ b/src/types.rs
@@ -217,7 +217,7 @@ pub enum ParsedType {
     Error(Error),
     Ident(Ident),
     IfElse(IfElse),
-    IndexSet(IndexSet),
+    Select(Select),
     Inherit(Inherit),
     InheritFrom(InheritFrom),
     Lambda(Lambda),
@@ -251,7 +251,7 @@ impl core::convert::TryFrom<SyntaxNode> for ParsedType {
             NODE_ERROR => Ok(ParsedType::Error(Error::cast(node).unwrap())),
             NODE_IDENT => Ok(ParsedType::Ident(Ident::cast(node).unwrap())),
             NODE_IF_ELSE => Ok(ParsedType::IfElse(IfElse::cast(node).unwrap())),
-            NODE_INDEX_SET => Ok(ParsedType::IndexSet(IndexSet::cast(node).unwrap())),
+            NODE_SELECT => Ok(ParsedType::Select(Select::cast(node).unwrap())),
             NODE_INHERIT => Ok(ParsedType::Inherit(Inherit::cast(node).unwrap())),
             NODE_INHERIT_FROM => Ok(ParsedType::InheritFrom(InheritFrom::cast(node).unwrap())),
             NODE_STRING => Ok(ParsedType::Str(Str::cast(node).unwrap())),
@@ -328,7 +328,7 @@ typed! [
             nth!(self; 2)
         }
     },
-    NODE_INDEX_SET => IndexSet: {
+    NODE_SELECT => Select: {
         /// Return the set being indexed
         pub fn set(&self) -> Option<SyntaxNode> {
             nth!(self; 0)
@@ -395,8 +395,8 @@ typed! [
     },
     NODE_OR_DEFAULT => OrDefault: {
         /// Return the indexing operation
-        pub fn index(&self) -> Option<IndexSet> {
-            nth!(self; (IndexSet) 0)
+        pub fn index(&self) -> Option<Select> {
+            nth!(self; (Select) 0)
         }
         /// Return the default value
         pub fn default(&self) -> Option<SyntaxNode> {

--- a/test_data/general/docs.expect
+++ b/test_data/general/docs.expect
@@ -73,7 +73,7 @@ NODE_ROOT 0..306 {
         NODE_APPLY 277..303 {
           NODE_APPLY 277..298 {
             NODE_APPLY 277..296 {
-              NODE_INDEX_SET 277..292 {
+              NODE_SELECT 277..292 {
                 NODE_IDENT 277..285 {
                   TOKEN_IDENT("builtins") 277..285
                 }

--- a/test_data/general/interpolation.expect
+++ b/test_data/general/interpolation.expect
@@ -64,7 +64,7 @@ NODE_ROOT 0..270 {
           NODE_STRING_INTERPOL 101..161 {
             TOKEN_INTERPOL_START("${") 101..103
             TOKEN_WHITESPACE("\n      ") 103..110
-            NODE_INDEX_SET 110..155 {
+            NODE_SELECT 110..155 {
               NODE_SET 110..153 {
                 TOKEN_CURLY_B_OPEN("{") 110..111
                 TOKEN_WHITESPACE("\n        ") 111..120

--- a/test_data/general/isset.expect
+++ b/test_data/general/isset.expect
@@ -54,7 +54,7 @@ NODE_ROOT 0..54 {
       TOKEN_ASSIGN("=") 32..33
       TOKEN_WHITESPACE(" ") 33..34
       NODE_OR_DEFAULT 34..51 {
-        NODE_INDEX_SET 34..46 {
+        NODE_SELECT 34..46 {
           NODE_SET 34..44 {
             TOKEN_CURLY_B_OPEN("{") 34..35
             TOKEN_WHITESPACE(" ") 35..36

--- a/test_data/parser/index_set/1.expect
+++ b/test_data/parser/index_set/1.expect
@@ -1,6 +1,6 @@
 NODE_ROOT 0..5 {
-  NODE_INDEX_SET 0..5 {
-    NODE_INDEX_SET 0..3 {
+  NODE_SELECT 0..5 {
+    NODE_SELECT 0..3 {
       NODE_IDENT 0..1 {
         TOKEN_IDENT("a") 0..1
       }

--- a/test_data/parser/index_set/3.expect
+++ b/test_data/parser/index_set/3.expect
@@ -1,7 +1,7 @@
 NODE_ROOT 0..33 {
-  NODE_INDEX_SET 0..33 {
-    NODE_INDEX_SET 0..28 {
-      NODE_INDEX_SET 0..20 {
+  NODE_SELECT 0..33 {
+    NODE_SELECT 0..28 {
+      NODE_SELECT 0..20 {
         NODE_IDENT 0..4 {
           TOKEN_IDENT("test") 0..4
         }

--- a/test_data/parser/interpolation/1.expect
+++ b/test_data/parser/interpolation/1.expect
@@ -6,7 +6,7 @@ NODE_ROOT 0..43 {
     NODE_STRING_INTERPOL 9..40 {
       TOKEN_INTERPOL_START("${") 9..11
       TOKEN_WHITESPACE(" ") 11..12
-      NODE_INDEX_SET 12..38 {
+      NODE_SELECT 12..38 {
         NODE_SET 12..32 {
           TOKEN_CURLY_B_OPEN("{") 12..13
           TOKEN_WHITESPACE(" ") 13..14

--- a/test_data/parser/invalid_syntax/1.expect
+++ b/test_data/parser/invalid_syntax/1.expect
@@ -1,7 +1,7 @@
 error: unexpected eof, wanted any of [TOKEN_IDENT]
 error: error node at 0..1
 NODE_ROOT 0..2 {
-  NODE_INDEX_SET 0..2 {
+  NODE_SELECT 0..2 {
     NODE_ERROR 0..1 {
       TOKEN_SQUARE_B_CLOSE("]") 0..1
     }

--- a/test_data/parser/isset/2.expect
+++ b/test_data/parser/isset/2.expect
@@ -1,8 +1,8 @@
 NODE_ROOT 0..14 {
   NODE_BIN_OP 0..14 {
     NODE_OR_DEFAULT 0..10 {
-      NODE_INDEX_SET 0..5 {
-        NODE_INDEX_SET 0..3 {
+      NODE_SELECT 0..5 {
+        NODE_SELECT 0..3 {
           NODE_IDENT 0..1 {
             TOKEN_IDENT("a") 0..1
           }


### PR DESCRIPTION
index_set is confusing, because it sounds like another kind of
attr_set, where attributes are numeric.

select is not super clear either, but I personally find it less
confusing and it is what the original parser uses