### PR TITLE
Support parsing dynamic inherit identifiers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -374,8 +374,8 @@ where
                         self.finish_node();
                     }
 
-                    while let Some(TOKEN_IDENT) = self.peek() {
-                        self.expect_ident();
+                    while self.peek() != Some(TOKEN_SEMICOLON) {
+                        self.parse_val();
                     }
 
                     self.expect(TOKEN_SEMICOLON);

--- a/test_data/parser/inherit/1.expect
+++ b/test_data/parser/inherit/1.expect
@@ -1,5 +1,5 @@
-NODE_ROOT 0..36 {
-  NODE_ATTR_SET 0..36 {
+NODE_ROOT 0..52 {
+  NODE_ATTR_SET 0..52 {
     TOKEN_CURLY_B_OPEN("{") 0..1
     NODE_KEY_VALUE 1..5 {
       NODE_KEY 1..2 {
@@ -45,6 +45,21 @@ NODE_ROOT 0..36 {
       }
       TOKEN_SEMICOLON(";") 34..35
     }
-    TOKEN_CURLY_B_CLOSE("}") 35..36
+    TOKEN_WHITESPACE(" ") 35..36
+    NODE_INHERIT 36..51 {
+      TOKEN_INHERIT("inherit") 36..43
+      TOKEN_WHITESPACE(" ") 43..44
+      NODE_DYNAMIC 44..50 {
+        TOKEN_DYNAMIC_START("${") 44..46
+        NODE_STRING 46..49 {
+          TOKEN_STRING_START("\"") 46..47
+          TOKEN_STRING_CONTENT("f") 47..48
+          TOKEN_STRING_END("\"") 48..49
+        }
+        TOKEN_DYNAMIC_END("}") 49..50
+      }
+      TOKEN_SEMICOLON(";") 50..51
+    }
+    TOKEN_CURLY_B_CLOSE("}") 51..52
   }
 }

--- a/test_data/parser/inherit/1.nix
+++ b/test_data/parser/inherit/1.nix
@@ -1,1 +1,1 @@
-{a=1;inherit b c;inherit (set) d e;}
+{a=1;inherit b c;inherit (set) d e; inherit ${"f"};}


### PR DESCRIPTION
Nix allows code like `inherit ${"foo"}` to inherit the "foo" attribute.
This was previously parsed as invalid code while nix allows using that.

This is a follow-up to a conversation I had with @jD91mZM2 a while ago on IRC. I hope I got the implementation right because I mostly guessed from the notes I took back then.