### PR TITLE
types: provide a Debug instance for ParsedType

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,7 @@ use crate::{
 macro_rules! typed {
     ($($kind:expr => $name:ident$(: $trait:ident)*$(: { $($block:tt)* })*),*) => {
         $(
-            #[derive(Clone)]
+            #[derive(Clone, Debug)]
             pub struct $name(SyntaxNode);
 
             impl TypedNode for $name {
@@ -213,7 +213,7 @@ pub trait Wrapper: TypedNode {
 
 pub struct ParsedTypeError(pub SyntaxKind);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ParsedType {
     Apply(Apply),
     Assert(Assert),


### PR DESCRIPTION
While consuming the output of this library it is sometimes very helpful
to have a printable represntation of `ParsedType`.