### PR TITLE
Fix memory leak while parsing improperly terminated `inherit`-expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -378,6 +378,9 @@ where
 
                     while self.peek() != Some(TOKEN_SEMICOLON) {
                         self.parse_val();
+                        if self.errors.last().map_or(false, |x| *x == ParseError::UnexpectedEOF) {
+                            break;
+                        }
                     }
 
                     self.expect(TOKEN_SEMICOLON);

--- a/test_data/parser/inherit/2.expect
+++ b/test_data/parser/inherit/2.expect
@@ -1,0 +1,13 @@
+error: unexpected end of file
+error: unexpected end of file, wanted any of [TOKEN_SEMICOLON]
+error: unexpected end of file
+error: unexpected end of file
+NODE_ROOT 0..13 {
+  NODE_LET_IN 0..13 {
+    TOKEN_LET("let") 0..3
+    TOKEN_WHITESPACE("\n  ") 3..6
+    NODE_INHERIT 6..13 {
+      TOKEN_INHERIT("inherit") 6..13
+    }
+  }
+}

--- a/test_data/parser/inherit/2.nix
+++ b/test_data/parser/inherit/2.nix
@@ -1,0 +1,2 @@
+let
+  inherit


### PR DESCRIPTION
First of all, big thanks to @fufexan who helped me to reliably reproduce
this.

Originally discovered in `rnix-lsp`[1], but I confirmed that
`nixpkgs-fmt` is also affected.

Basically, when having an expression such as

    let
      inherit

the parser would wait for a `TOKEN_SEMICOLON` indefinitely. The actual
problem however is that `self.parse_val()` always detects the SAME
syntax-error, i.e. "unexpected EOF". This will be written indefinetely
into `self.errors`. However, `errors` is of type `Vec<ParseError>` and a
vector in Rust grows in an amortized fashion[2] which means that if an
entry is pushed and the vector exceeds the currently allocated size, it
will be ~doubled (though the exact growth-factor isn't constant).

This essentially means that the buffer is growing exponentially pretty fast
and - according to KDE heaptrack - my system allocated ~9.5GB after 20s
while running some tests.

I added an exit-condition to the loop traversing through
`inherit`-subexpressions to avoid that. Checking for an "unexpected EOF"
is actually sufficient here:

* There's either a `;` later in the expression causing the loop to
  terminate and causing an actual "unexpected token" error then.

* Otherwise, `parse_val` will go through the tokens until a matching
  semicolon is found (which is not the case) and then reach the end of
  the file. In that case, `unexpected EOF` is returned by `parse_val`.

[1] https://github.com/nix-community/rnix-lsp/issues/33
[2] https://www.cs.cornell.edu/courses/cs3110/2011sp/Lectures/lec20-amortized/amortized.htm