### PR TITLE
make BinOp::operator return an optional value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,14 +91,14 @@ mod tests {
         let root = ast.root().inner().and_then(BinOp::cast).unwrap();
         let operation = root.lhs().and_then(BinOp::cast).unwrap();
 
-        assert_eq!(root.operator(), BinOpKind::Add);
-        assert_eq!(operation.operator(), BinOpKind::Add);
+        assert_eq!(root.operator().unwrap(), BinOpKind::Add);
+        assert_eq!(operation.operator().unwrap(), BinOpKind::Add);
 
         let lhs = operation.lhs().and_then(Value::cast).unwrap();
         assert_eq!(lhs.to_value(), Ok(NixValue::Integer(1)));
 
         let rhs = operation.rhs().and_then(BinOp::cast).unwrap();
-        assert_eq!(rhs.operator(), BinOpKind::Mul);
+        assert_eq!(rhs.operator().unwrap(), BinOpKind::Mul);
     }
     #[test]
     fn t_macro() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -428,8 +428,8 @@ typed! [
             nth!(self; 0)
         }
         /// Return the operator
-        pub fn operator(&self) -> BinOpKind {
-            self.first_token().and_then(|t| BinOpKind::from_token(t.kind())).expect("invalid ast")
+        pub fn operator(&self) -> Option<BinOpKind> {
+            self.first_token().and_then(|t| BinOpKind::from_token(t.kind()))
         }
         /// Return the right hand side of the binary operation
         pub fn rhs(&self) -> Option<SyntaxNode> {


### PR DESCRIPTION
Since rowan produces syntax trees even if there are errors present in
the source, every function that operates on the tree has to assume that
syntax nodes are partially constructed. As a result, every function on
the tree should return an optional value.

This is already the case with most functions, `BinOp::operator` has been
updated to behave the same way.

This PR closes  #30.