### PR TITLE
implement more traits for ParsedTypeError

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -211,7 +211,16 @@ pub trait Wrapper: TypedNode {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
 pub struct ParsedTypeError(pub SyntaxKind);
+
+impl fmt::Display for ParsedTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "invalid cast from kind {:?}", self.0)
+    }
+}
+
+impl std::error::Error for ParsedTypeError {}
 
 #[derive(Clone, Debug)]
 pub enum ParsedType {


### PR DESCRIPTION
- derive Debug, Copy and Clone
- implement Display and Error

Copy and Clone are handy because the inner type; SyntaxKind already
implements these. Debug, Display and Error make it easier to call panic
and unwrap on this type.