### PR TITLE
example for stdin parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ rnix nowadays uses [@matklad](https://github.com/matklad)'s
 
 Examples can be found in the `examples/` directory.
 
+You can parse Nix expressions from standard input using the `from-stdin` example.
+To try that, run the following in your shell:
+```sh
+echo "[hello nix]" | cargo run --quiet --example from-stdin
+```
+ 
+
 You may also want to see
 [nix-explorer](https://gitlab.com/jD91mZM2/nix-explorer): An example
 that highlights AST nodes in Nix code. This demonstrates how

--- a/examples/from-stdin.rs
+++ b/examples/from-stdin.rs
@@ -1,0 +1,14 @@
+use rnix::types::*;
+use std::{io, io::Read};
+
+fn main() {
+    let mut content = String::new();
+    io::stdin().read_to_string(&mut content).expect("could not read nix from stdin");
+    let ast = rnix::parse(&content);
+
+    for error in ast.errors() {
+        println!("error: {}", error);
+    }
+
+    println!("{}", ast.root().dump());
+}


### PR DESCRIPTION
When debugging #46 I wanted to narrow down the failing snippet. Using a file was too unwiedly.

You can run this snippet with `echo "0.5" | cargo run --quiet --example from-stdin`


<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

<!--
Please summarize the changes you've made and the motivation behind it.
-->

### Backwards-incompatible changes

<!--
If applicable, please summarize which changes of your PR are backwards-incompatible
to the latest release.
-->

### Further context

<!--
If applicable, please give further context such as related issues / PRs,
an explanation of the problem you're aiming to solve or anything else you also
consider relevant.
-->
