### PR TITLE
refactor(flake): rework using fenix and buildRustPackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 
 /.direnv/
+
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1634172192,
-        "narHash": "sha256-FBF4U/T+bMg4sEyT/zkgasvVquGzgdAf4y8uCosKMmo=",
+        "lastModified": 1636800699,
+        "narHash": "sha256-SwbyVxXffu3G2ulJIbTf0iQfqhbGbdml4Dyv5j9BiAI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2cf9db0e3d45b9d00f16f2836cb1297bcadc475e",
+        "rev": "2fa862644fc15ecb525eb8cd0a60276f1c340c7c",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,23 @@
 {
   "nodes": {
-    "import-cargo": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
       "locked": {
-        "lastModified": 1594305518,
-        "narHash": "sha256-frtArgN42rSaEcEOYWg8sVPMUK+Zgch3c+wejcpX3DY=",
-        "owner": "edolstra",
-        "repo": "import-cargo",
-        "rev": "25d40be4a73d40a2572e0cc233b83253554f06c5",
+        "lastModified": 1636871041,
+        "narHash": "sha256-LvyVEXAwz4/IMmCEC7px6wX28a3leWskIHNMi2DZt98=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "7fd9dc7a56ac3cb1a77b9199b5c9fc7042b0acf8",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "import-cargo",
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
@@ -33,9 +39,26 @@
     },
     "root": {
       "inputs": {
-        "import-cargo": "import-cargo",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1636846936,
+        "narHash": "sha256-3xJCEfFdYkdxrQ3MP20ZbcjOBPxuG8m89WxpC4WkeW0=",
+        "owner": "rust-analyzer",
+        "repo": "rust-analyzer",
+        "rev": "766b52b598ad1639e5b815b87dbd3fa3be155219",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-analyzer",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "utils": {

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
   }
   // utils.lib.eachDefaultSystem (system:
     let
-      pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+      pkgs = import nixpkgs { inherit system; overlays = [ fenix.overlay self.overlay ]; };
     in
     {
       devShell = pkgs.mkShell {
@@ -66,6 +66,7 @@
         inputsFrom = pkgs.lib.attrValues self.packages.${system};
 
         nativeBuildInputs = with pkgs; [
+          rust-analyzer-nightly
           cargo-edit
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -3,61 +3,76 @@
 
   inputs = {
     utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
-    import-cargo.url = github:edolstra/import-cargo;
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, utils, import-cargo }:
-    {
-      overlay = final: prev: let
+  outputs = { self, fenix, nixpkgs, utils }: {
+    overlay = final: prev:
+      let
+        fenix' = (fenix.overlay final prev).fenix;
+
+        rustToolchain = fenix'.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          sha256 = "sha256-MJyH6FPVI7diJql9d+pifu5aoqejvvXyJ+6WSJDWaIA=";
+        };
+
+        rustPlatform = final.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+
         target = final.rust.toRustTarget final.stdenv.hostPlatform;
-        flags = "--release --offline --target ${target}";
-        inherit (import-cargo.builders) importCargo;
-      in {
-        rnix-parser = final.stdenv.mkDerivation {
+      in
+      {
+        rnix-parser = rustPlatform.buildRustPackage {
           pname = "rnix-parser";
           version = "0.9.1";
+
           src = final.lib.cleanSource ./.;
-          nativeBuildInputs = with final; [
-            rustc cargo
-            (importCargo { lockFile = ./Cargo.lock; inherit (final) pkgs; }).cargoHome
-          ];
+          cargoLock.lockFile = ./Cargo.lock;
+
+          postBuild = "cargo doc";
+
+          doCheck = true;
+          postCheck = "cargo bench";
 
           outputs = [ "out" "doc" ];
-          doCheck = true;
-
-          buildPhase = ''
-            cargo build ${flags}
-            cargo doc ${flags}
-          '';
-
-          checkPhase = ''
-            cargo test ${flags}
-            cargo bench
-          '';
-
           installPhase = ''
+            runHook preInstall
             mkdir -p $out/lib
             mkdir -p $doc/share/doc/rnix
 
-            cp -r ./target/${target}/doc $doc/share/doc/rnix
-            cp ./target/${target}/release/librnix.rlib $out/lib/
+            cp ./target/${target}/$cargoBuildType/librnix.rlib $out/lib
+            cp -r ./target/doc/. $doc/share/doc/rnix
+            runHook postInstall
           '';
+
+          passthru.rustPlatform = rustPlatform;
         };
       };
-    }
-    // utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
-      in
-      rec {
-        # `nix develop`
-        devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ rustfmt rustc cargo ];
-        };
+  }
+  // utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+    in
+    {
+      devShell = pkgs.mkShell {
+        name = "rnix-parser";
 
-        packages.rnix-parser = pkgs.rnix-parser;
-        defaultPackage = packages.rnix-parser;
-      }
-    );
+        inputsFrom = pkgs.lib.attrValues self.packages.${system};
+
+        nativeBuildInputs = with pkgs; [
+          cargo-edit
+        ];
+      };
+
+      packages.rnix-parser = pkgs.rnix-parser;
+
+      defaultPackage = self.packages.${system}.rnix-parser;
+    }
+  );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+[toolchain]
+channel = "1.56.1"
+components = [
+    "cargo",
+    "clippy",
+    "rust-analysis",
+    "rust-src",
+    "rust-std",
+    "rustc",
+    "rustfmt",
+]


### PR DESCRIPTION
- chore(flake): update inputs
- refactor(gitignore): add result, result-*
- feat: add rust-toolchain file
- refactor(flake): rework using fenix and buildRustPackage


### Summary & Motivation

While working on bumping to rowan 0.15 (which requires Rust 2021) I got annoyed
at the current build's lack of pinning to a given Rust release, regardless of
the one pinned in nixpkgs.

With this change we use [fenix](https://github.com/nix-community/fenix) to pin
our Rust to the one in the standard `rust-toolchain.toml` file. This should also
allow us to enforce a MSRV (Minimum Supported Rust Version).

In the process, I also decided to use the rust build tooling already present in
nixpkgs, and then using `inputsFrom` for the `devShell`. Overall, I think this
has led to a cleaner and easier to read flake.

### Backwards-incompatible changes

<!--
If applicable, please summarize which changes of your PR are backwards-incompatible
to the latest release.
-->
Hopefully none, I suppose if someone were adamant about using an ancient nixpkgs
(before `makeRustPlatform`) things wouldn't work.

