### PR TITLE
make UnaryOp::operator return Option<UnaryOpKind>

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -529,8 +529,8 @@ typed! [
     },
     NODE_UNARY_OP => UnaryOp: {
         /// Return the operator
-        pub fn operator(&self) -> UnaryOpKind {
-            self.first_token().and_then(|t| UnaryOpKind::from_token(t.kind())).expect("invalid ast")
+        pub fn operator(&self) -> Option<UnaryOpKind> {
+            self.first_token().and_then(|t| UnaryOpKind::from_token(t.kind()))
         }
         /// Return the value in the operation
         pub fn value(&self) -> Option<SyntaxNode> {


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

<!--
Please summarize the changes you've made and the motivation behind it.
-->

`UnaryOp::operator` should not panic if the AST is incomplete, and should return `None` instead. This is also now uniform with `BinaryOp::operator`.

### Backwards-incompatible changes

<!--
If applicable, please summarize which changes of your PR are backwards-incompatible
to the latest release.
-->
Changes the return type of `UnaryOp::operator`.

