### PR TITLE
Support for 'true' and 'false' to be interperted as 'Boolean' literals

### DIFF
--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -55,6 +55,7 @@ pub enum SyntaxKind {
     TOKEN_OR,
 
     // Identifiers and values
+    TOKEN_BOOLEAN,
     TOKEN_DYNAMIC_END,
     TOKEN_DYNAMIC_START,
     TOKEN_FLOAT,
@@ -108,7 +109,7 @@ impl SyntaxKind {
     /// Returns true if this token is a literal, such as an integer or a string
     pub fn is_literal(self) -> bool {
         match self {
-            TOKEN_FLOAT | TOKEN_INTEGER | TOKEN_PATH | TOKEN_URI => true,
+            TOKEN_FLOAT | TOKEN_INTEGER | TOKEN_PATH | TOKEN_URI | TOKEN_BOOLEAN => true,
             _ => false,
         }
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -417,9 +417,11 @@ impl<'a> Iterator for Tokenizer<'a> {
                         "if" => TOKEN_IF,
                         "in" => TOKEN_IN,
                         "inherit" => TOKEN_INHERIT,
+                        "false" => TOKEN_BOOLEAN,
                         "let" => TOKEN_LET,
                         "rec" => TOKEN_REC,
                         "then" => TOKEN_THEN,
+                        "true" => TOKEN_BOOLEAN,
                         "with" => TOKEN_WITH,
                         _ => {
                             if matches!(self.ctx.last_mut().unwrap().todo, Some(Todo::Path)) {
@@ -1066,24 +1068,24 @@ mod tests {
         assert_eq!(
             tokenize("false -> !false && false == true || true"),
             tokens![
-                (TOKEN_IDENT, "false"),
+                (TOKEN_BOOLEAN, "false"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_IMPLICATION, "->"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INVERT, "!"),
-                (TOKEN_IDENT, "false"),
+                (TOKEN_BOOLEAN, "false"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_IDENT, "false"),
+                (TOKEN_BOOLEAN, "false"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_EQUAL, "=="),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_IDENT, "true"),
+                (TOKEN_BOOLEAN, "true"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_OR, "||"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_IDENT, "true"),
+                (TOKEN_BOOLEAN, "true"),
             ]
         );
         assert_eq!(
@@ -1167,7 +1169,7 @@ mod tests {
             tokens![
                 (TOKEN_IF, "if"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_IDENT, "false"),
+                (TOKEN_BOOLEAN, "false"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_THEN, "then"),
                 (TOKEN_WHITESPACE, " "),
@@ -1177,7 +1179,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_IF, "if"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_IDENT, "true"),
+                (TOKEN_BOOLEAN, "true"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_THEN, "then"),
                 (TOKEN_WHITESPACE, " "),

--- a/test_data/general/ifs.expect
+++ b/test_data/general/ifs.expect
@@ -145,8 +145,8 @@ NODE_ROOT 0..284 {
         TOKEN_WHITESPACE(" ") 208..209
         TOKEN_ASSIGN("=") 209..210
         TOKEN_WHITESPACE(" ") 210..211
-        NODE_IDENT 211..216 {
-          TOKEN_IDENT("false") 211..216
+        NODE_LITERAL 211..216 {
+          TOKEN_BOOLEAN("false") 211..216
         }
         TOKEN_SEMICOLON(";") 216..217
       }
@@ -199,8 +199,8 @@ NODE_ROOT 0..284 {
           }
           TOKEN_SEMICOLON(";") 275..276
           TOKEN_WHITESPACE(" ") 276..277
-          NODE_IDENT 277..281 {
-            TOKEN_IDENT("true") 277..281
+          NODE_LITERAL 277..281 {
+            TOKEN_BOOLEAN("true") 277..281
           }
         }
         TOKEN_SEMICOLON(";") 281..282

--- a/test_data/general/with-import-let-in.expect
+++ b/test_data/general/with-import-let-in.expect
@@ -90,8 +90,8 @@ NODE_ROOT 0..150 {
               TOKEN_WHITESPACE(" ") 105..106
               TOKEN_ASSIGN("=") 106..107
               TOKEN_WHITESPACE(" ") 107..108
-              NODE_IDENT 108..112 {
-                TOKEN_IDENT("true") 108..112
+              NODE_LITERAL 108..112 {
+                TOKEN_BOOLEAN("true") 108..112
               }
               TOKEN_SEMICOLON(";") 112..113
             }

--- a/test_data/parser/ifs/1.expect
+++ b/test_data/parser/ifs/1.expect
@@ -1,7 +1,7 @@
 NODE_ROOT 0..33 {
   NODE_BIN_OP 0..33 {
-    NODE_IDENT 0..5 {
-      TOKEN_IDENT("false") 0..5
+    NODE_LITERAL 0..5 {
+      TOKEN_BOOLEAN("false") 0..5
     }
     TOKEN_WHITESPACE(" ") 5..6
     TOKEN_IMPLICATION("->") 6..8
@@ -9,24 +9,24 @@ NODE_ROOT 0..33 {
       NODE_BIN_OP 8..27 {
         NODE_UNARY_OP 8..14 {
           TOKEN_INVERT("!") 8..9
-          NODE_IDENT 9..14 {
-            TOKEN_IDENT("false") 9..14
+          NODE_LITERAL 9..14 {
+            TOKEN_BOOLEAN("false") 9..14
           }
         }
         TOKEN_AND("&&") 14..16
         NODE_BIN_OP 16..27 {
-          NODE_IDENT 16..21 {
-            TOKEN_IDENT("false") 16..21
+          NODE_LITERAL 16..21 {
+            TOKEN_BOOLEAN("false") 16..21
           }
           TOKEN_EQUAL("==") 21..23
-          NODE_IDENT 23..27 {
-            TOKEN_IDENT("true") 23..27
+          NODE_LITERAL 23..27 {
+            TOKEN_BOOLEAN("true") 23..27
           }
         }
       }
       TOKEN_OR("||") 27..29
-      NODE_IDENT 29..33 {
-        TOKEN_IDENT("true") 29..33
+      NODE_LITERAL 29..33 {
+        TOKEN_BOOLEAN("true") 29..33
       }
     }
   }

--- a/test_data/parser/ifs/4.expect
+++ b/test_data/parser/ifs/4.expect
@@ -2,8 +2,8 @@ NODE_ROOT 0..44 {
   NODE_IF_ELSE 0..44 {
     TOKEN_IF("if") 0..2
     TOKEN_WHITESPACE(" ") 2..3
-    NODE_IDENT 3..8 {
-      TOKEN_IDENT("false") 3..8
+    NODE_LITERAL 3..8 {
+      TOKEN_BOOLEAN("false") 3..8
     }
     TOKEN_WHITESPACE(" ") 8..9
     TOKEN_THEN("then") 9..13
@@ -17,8 +17,8 @@ NODE_ROOT 0..44 {
     NODE_IF_ELSE 21..44 {
       TOKEN_IF("if") 21..23
       TOKEN_WHITESPACE(" ") 23..24
-      NODE_IDENT 24..28 {
-        TOKEN_IDENT("true") 24..28
+      NODE_LITERAL 24..28 {
+        TOKEN_BOOLEAN("true") 24..28
       }
       TOKEN_WHITESPACE(" ") 28..29
       TOKEN_THEN("then") 29..33

--- a/test_data/parser/isset/1.expect
+++ b/test_data/parser/isset/1.expect
@@ -12,8 +12,8 @@ NODE_ROOT 0..11 {
       }
     }
     TOKEN_AND("&&") 5..7
-    NODE_IDENT 7..11 {
-      TOKEN_IDENT("true") 7..11
+    NODE_LITERAL 7..11 {
+      TOKEN_BOOLEAN("true") 7..11
     }
   }
 }


### PR DESCRIPTION
See #81 

### Summary & Motivation

true and false are literal booleans...

### Backwards-incompatible changes

true and false are not TOKEN_BOOLEAN opposed to TOKEN_IDENT additionally they are LITERAL kind. Sooo, this may break things? Easy fix, I don't understand why this wasn't already in here...