### PR TITLE
keep flake package version in sync with Cargo.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
       in {
         rnix-parser = final.stdenv.mkDerivation {
           pname = "rnix-parser";
-          version = "0.9.1";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
           src = final.lib.cleanSource ./.;
           nativeBuildInputs = with final; [
             rustc cargo


### PR DESCRIPTION
Fixes out of date version in the flake package and keeps it synchronized with the version in Cargo.toml