### PR TITLE
Export tokenize function from tokenizer module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use self::{
     kinds::SyntaxKind,
     parser::AST,
     value::{StrPart, Value as NixValue},
+    tokenizer::tokenize,
 };
 
 pub use rowan::{

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -58,6 +58,11 @@ impl PartialEq for State<'_> {
 }
 impl Eq for State<'_> {}
 
+/// A convenience function for tokenizing the given input
+pub fn tokenize(input: &str) -> Vec<(SyntaxKind, SmolStr)> {
+    Tokenizer::new(input).collect()
+}
+
 /// The tokenizer. You may want to use the `tokenize` convenience function from this module instead.
 pub struct Tokenizer<'a> {
     ctx: Vec<Context>,
@@ -465,15 +470,10 @@ impl<'a> Iterator for Tokenizer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        SyntaxKind::{self, *},
-        Tokenizer,
-    };
-    use smol_str::SmolStr;
+    use crate::tokenizer::tokenize;
 
-    fn tokenize(input: &str) -> Vec<(SyntaxKind, SmolStr)> {
-        Tokenizer::new(input).collect()
-    }
+    use super::SyntaxKind::{self, *};
+    use smol_str::SmolStr;
 
     macro_rules! tokens {
         ($(($token:expr, $str:expr),)*) => {


### PR DESCRIPTION
<!--
Feel free to remove paragraphs that don't apply to your PR.
-->

### Summary & Motivation

The `Tokenizer` doc mentions using the `tokenize` convenience function, but this isn't exported from the module.

This is slightly nicer than constructing and collecting the Tokenizer manually, because the type is explicit. i.e., compare
```rust
let tokens = Tokenizer::new(input).collect::<Vec<(SyntaxKind, SmolStr)>>();
```
vs
```rust
let tokens = tokenize(input);
```