### PR TITLE
chore+refactor: upgrade rowan to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "countme"
-version = "2.0.4"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "criterion"
@@ -201,9 +201,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "hermit-abi"
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.12.6"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b36e449f3702f3b0c821411db1cbdf30fb451726a9456dce5dabcd44420043"
+checksum = "ce1f383129e417a6265b16ed78e6e9307748f0863b2ba75f78ff14717db5b017"
 dependencies = [
  "countme",
  "hashbrown",
@@ -462,9 +462,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d92beeab217753479be2f74e54187a6aed4c125ff0703a866c3147a02f0c6dd"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "all-packages"
 
 [dependencies]
 cbitset = "0.2.0"
-rowan = "0.12.5"
+rowan = "0.15.0"
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/examples/list-fns.rs
+++ b/examples/list-fns.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if let Some(lambda) = entry.value().and_then(Lambda::cast) {
             if let Some(attr) = entry.key() {
                 let ident = attr.path().last().and_then(Ident::cast);
-                let s = ident.as_ref().map_or("error", Ident::as_str);
+                let s = ident.as_ref().map_or_else(|| "error".to_string(), Ident::to_inner_string);
                 println!("Function name: {}", s);
                 if let Some(comment) = find_comment(attr.node().clone()) {
                     println!("-> Doc: {}", comment);
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let mut value = Some(lambda);
                 while let Some(lambda) = value {
                     let ident = lambda.arg().and_then(Ident::cast);
-                    let s = ident.as_ref().map_or("error", Ident::as_str);
+                    let s = ident.as_ref().map_or_else(|| "error".to_string(), Ident::to_inner_string);
                     println!("-> Arg: {}", s);
                     if let Some(comment) = lambda.arg().and_then(find_comment) {
                         println!("--> Doc: {}", comment);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,10 @@ mod tests {
         let inherit = set.inherits().nth(1).unwrap();
 
         let from = inherit.from().unwrap().inner().and_then(Ident::cast).unwrap();
-        assert_eq!(from.as_str(), "set");
+        assert_eq!(from.to_inner_token().text(), "set");
         let mut children = inherit.idents();
-        assert_eq!(children.next().unwrap().as_str(), "z");
-        assert_eq!(children.next().unwrap().as_str(), "a");
+        assert_eq!(children.next().unwrap().to_inner_token().text(), "z");
+        assert_eq!(children.next().unwrap().to_inner_token().text(), "a");
         assert!(children.next().is_none());
     }
     #[test]


### PR DESCRIPTION
### Summary & Motivation

upgrade `rowan` to v0.15, broken out of https://github.com/nix-community/rnix-parser/pull/36 (although I've done it from scratch in this PR). => to reduce the scope of https://github.com/nix-community/rnix-parser/pull/36.

### Backwards-incompatible changes

* replaces `TokenWrapper::as_str :: . -> &str` with `TokenWrapper::to_inner_string :: . -> String`. I didn't know how to access the inner green node + children without allocations or dangling references... I added a note about that to the docstring
* `Value::to_value` now uses a different way to retrieve the token kind, which should usually be equivalent, but I don't know if this breaks any edge case