### PR TITLE
Fix multiline dollar escape

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -124,7 +124,11 @@ impl<'a> Tokenizer<'a> {
                         self.next();
                         self.peek()
                     } {
-                        Some('\'') | Some('\\') | Some('$') => {
+                        Some('\'') | Some('$') => {
+                            self.next().unwrap();
+                        }
+                        Some('\\') => {
+                            self.next().unwrap();
                             self.next().unwrap();
                         }
                         _ => {
@@ -599,6 +603,7 @@ mod tests {
           indented by two
         \'\'\'\'\
         ''${ interpolation was escaped }
+        ''\${ interpolation was escaped }
         two single quotes: '''
         three single quotes: ''''
     '';
@@ -619,6 +624,7 @@ mod tests {
           indented by two
         \'\'\'\'\
         ''${ interpolation was escaped }
+        ''\${ interpolation was escaped }
         two single quotes: '''
         three single quotes: ''''
     "#


### PR DESCRIPTION
### Summary & Motivation
Previously, if the tokenizer encountered the sequence of characters `''\$`, `next_string` would consume the first 3 and then loop back around and see the `$` next, which it treated as the start of an interpolation.

With this change, it will instead always immediately consume the next character after `''\` before looping back. This is correct, because [`''\x` is a valid escape sequence for any `x`](https://github.com/NixOS/nix/blob/59764eb842d0da4f6fcf4ce4b85bf02ac1ae26fc/src/libexpr/lexer.l#L218).

### Further context
Fixes #100 