### PR TITLE
Correctly remove multiline trailing whitespace

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -142,17 +142,6 @@ pub fn remove_indent(input: &str, initial: bool, indent: usize) -> String {
     }
     output
 }
-/// Remove any trailing whitespace from a string
-pub fn remove_trailing(string: &mut String) {
-    let trailing: usize = string
-        .chars()
-        .rev()
-        .take_while(|&c| c != '\n' && c.is_whitespace())
-        .map(char::len_utf8)
-        .sum();
-    let len = string.len();
-    string.truncate(len - trailing);
-}
 
 /// An error that occured when parsing a value from a string
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -272,9 +261,14 @@ pub(crate) fn string_parts(string: &types::Str) -> Vec<StrPart> {
         if let StrPart::Literal(ref mut text) = part {
             if multiline {
                 *text = remove_indent(text, i == 0, common);
+                // If the last literal is of the form `X\nY`, exclude Y if it consists solely of spaces
                 if i == literals - 1 {
-                    // Last index
-                    remove_trailing(text);
+                    match text.rfind('\n') {
+                        Some(p) if text[p + 1..].chars().all(|c| c == ' ') => {
+                            text.truncate(p + 1);
+                        }
+                        _ => {}
+                    }
                 }
             }
             *text = unescape(text, multiline);
@@ -299,6 +293,36 @@ mod tests {
         assert_eq!(remove_common_indent("\n  \n    \n \n "), "\n\n\n");
         assert_eq!(remove_common_indent("\n  \n    \n a\n"), " \n   \na\n");
         assert_eq!(remove_common_indent("  \n    \n a\n"), "   \na\n");
+    }
+    #[test]
+    fn parts_trailing_ws_single_line() {
+        use crate::types::{ParsedType, Wrapper};
+        use crate::value::StrPart;
+        use std::convert::TryFrom;
+
+        let str = "''hello ''";
+        let parsed = crate::parse(str);
+        match ParsedType::try_from(parsed.root().inner().expect("root")) {
+            Ok(ParsedType::Str(str)) => {
+                assert_eq!(str.parts(), vec![StrPart::Literal("hello ".to_string())])
+            }
+            _ => unreachable!(),
+        }
+    }
+    #[test]
+    fn parts_trailing_ws_multiline() {
+        use crate::types::{ParsedType, Wrapper};
+        use crate::value::StrPart;
+        use std::convert::TryFrom;
+
+        let str = "''hello\n ''";
+        let parsed = crate::parse(str);
+        match ParsedType::try_from(parsed.root().inner().expect("root")) {
+            Ok(ParsedType::Str(str)) => {
+                assert_eq!(str.parts(), vec![StrPart::Literal("hello\n".to_string())])
+            }
+            _ => unreachable!(),
+        }
     }
     #[test]
     fn parts() {


### PR DESCRIPTION
### Summary & Motivation
Previously, trailing whitespace on the last line of a multiline string was always removed, but this is not necessarily correct. For example, the string `''hello    ''` should keep its trailing whitespace.

This PR attempts to mimic the [logic used in the reference implementation of the parser](https://github.com/NixOS/nix/blob/fbd0a6c6e2e87f6679fe5cabaddaa877cf3e5a90/src/libexpr/parser.y#L268-L274) to instead only remove the final line if it consists solely of whitespace.