### PR TITLE
Mimic Nix's behavior of contextual keyword "or"

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -250,9 +250,7 @@ impl Select {
     ng! { expr, Expr, 0 }
     tg! { dot_token, . }
     ng! { attrpath, Attrpath, 0 }
-    // we should either add or as a token in the lexer
-    // or just find a token with text "or"
-    // tg! { or_token, or }
+    tg! { or_token, or }
     ng! { default_expr, Expr, 1 }
 }
 

--- a/src/ast/operators.rs
+++ b/src/ast/operators.rs
@@ -33,7 +33,7 @@ impl BinOpKind {
             TOKEN_MUL => Some(BinOpKind::Mul),
             TOKEN_DIV => Some(BinOpKind::Div),
 
-            TOKEN_AND => Some(BinOpKind::And),
+            TOKEN_AND_AND => Some(BinOpKind::And),
             TOKEN_EQUAL => Some(BinOpKind::Equal),
             TOKEN_IMPLICATION => Some(BinOpKind::Implication),
             TOKEN_LESS => Some(BinOpKind::Less),
@@ -41,7 +41,7 @@ impl BinOpKind {
             TOKEN_MORE => Some(BinOpKind::More),
             TOKEN_MORE_OR_EQ => Some(BinOpKind::MoreOrEq),
             TOKEN_NOT_EQUAL => Some(BinOpKind::NotEqual),
-            TOKEN_OR => Some(BinOpKind::Or),
+            TOKEN_OR_OR => Some(BinOpKind::Or),
 
             _ => None,
         }

--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -44,7 +44,7 @@ pub enum SyntaxKind {
     TOKEN_MUL,
     TOKEN_DIV,
 
-    TOKEN_AND,
+    TOKEN_AND_AND,
     TOKEN_EQUAL,
     TOKEN_IMPLICATION,
     TOKEN_LESS,
@@ -52,7 +52,7 @@ pub enum SyntaxKind {
     TOKEN_MORE,
     TOKEN_MORE_OR_EQ,
     TOKEN_NOT_EQUAL,
-    TOKEN_OR,
+    TOKEN_OR_OR,
 
     // Identifiers and values
     TOKEN_DYNAMIC_END,

--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -14,6 +14,7 @@ pub enum SyntaxKind {
     TOKEN_IN,
     TOKEN_INHERIT,
     TOKEN_LET,
+    TOKEN_OR,
     TOKEN_REC,
     TOKEN_THEN,
     TOKEN_WITH,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,6 +7,7 @@ macro_rules! T {
     (in)      => ($crate::SyntaxKind::TOKEN_IN);
     (inherit) => ($crate::SyntaxKind::TOKEN_INHERIT);
     (let)     => ($crate::SyntaxKind::TOKEN_LET);
+    (or)      => ($crate::SyntaxKind::TOKEN_OR);
     (rec)     => ($crate::SyntaxKind::TOKEN_REC);
     (then)    => ($crate::SyntaxKind::TOKEN_THEN);
     (with)    => ($crate::SyntaxKind::TOKEN_WITH);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,7 +35,7 @@ macro_rules! T {
     (*)       => ($crate::SyntaxKind::TOKEN_MUL);
     (/)       => ($crate::SyntaxKind::TOKEN_DIV);
 
-    (&&)      => ($crate::SyntaxKind::TOKEN_AND);
+    (&&)      => ($crate::SyntaxKind::TOKEN_AND_AND);
     (==)      => ($crate::SyntaxKind::TOKEN_EQUAL);
     (=>)      => ($crate::SyntaxKind::TOKEN_IMPLICATION);
     (<)       => ($crate::SyntaxKind::TOKEN_LESS);
@@ -43,6 +43,6 @@ macro_rules! T {
     (>)       => ($crate::SyntaxKind::TOKEN_MORE);
     (>=)      => ($crate::SyntaxKind::TOKEN_MORE_OR_EQ);
     (!=)      => ($crate::SyntaxKind::TOKEN_NOT_EQUAL);
-    (||)      => ($crate::SyntaxKind::TOKEN_OR);
+    (||)      => ($crate::SyntaxKind::TOKEN_OR_OR);
     ($kind:ident) => ($crate::SyntaxKind::$kind);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -689,10 +689,10 @@ where
         self.handle_operation_left(true, Self::parse_compare, &[TOKEN_EQUAL, TOKEN_NOT_EQUAL])
     }
     fn parse_and(&mut self) -> Checkpoint {
-        self.handle_operation_left(false, Self::parse_equal, &[TOKEN_AND])
+        self.handle_operation_left(false, Self::parse_equal, &[TOKEN_AND_AND])
     }
     fn parse_or(&mut self) -> Checkpoint {
-        self.handle_operation_left(false, Self::parse_and, &[TOKEN_OR])
+        self.handle_operation_left(false, Self::parse_and, &[TOKEN_OR_OR])
     }
     fn parse_implication(&mut self) -> Checkpoint {
         self.handle_operation_right(Self::parse_or, &[TOKEN_IMPLICATION])

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -432,6 +432,8 @@ impl<'a> Tokenizer<'a> {
                         "in" => TOKEN_IN,
                         "inherit" => TOKEN_INHERIT,
                         "let" => TOKEN_LET,
+                        // "or" is a contextual keyword and will be handled in the parser.
+                        "or" => TOKEN_OR,
                         "rec" => TOKEN_REC,
                         "then" => TOKEN_THEN,
                         "with" => TOKEN_WITH,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -384,11 +384,11 @@ impl<'a> Tokenizer<'a> {
             }
             '&' if self.peek() == Some('&') => {
                 self.next().unwrap();
-                TOKEN_AND
+                TOKEN_AND_AND
             }
             '|' if self.peek() == Some('|') => {
                 self.next().unwrap();
-                TOKEN_OR
+                TOKEN_OR_OR
             }
             '<' if self.peek() == Some('=') => {
                 self.next().unwrap();
@@ -1135,7 +1135,7 @@ mod tests {
                 (TOKEN_INVERT, "!"),
                 (TOKEN_IDENT, "false"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_AND, "&&"),
+                (TOKEN_AND_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_IDENT, "false"),
                 (TOKEN_WHITESPACE, " "),
@@ -1143,7 +1143,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_IDENT, "true"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_OR, "||"),
+                (TOKEN_OR_OR, "||"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_IDENT, "true"),
             ]
@@ -1157,7 +1157,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_AND, "&&"),
+                (TOKEN_AND_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),
@@ -1165,7 +1165,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_AND, "&&"),
+                (TOKEN_AND_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),
@@ -1173,7 +1173,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "1"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_AND, "&&"),
+                (TOKEN_AND_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),
@@ -1191,7 +1191,7 @@ mod tests {
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "1"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_AND, "&&"),
+                (TOKEN_AND_AND, "&&"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_INTEGER, "2"),
                 (TOKEN_WHITESPACE, " "),

--- a/test_data/general/isset.expect
+++ b/test_data/general/isset.expect
@@ -83,7 +83,7 @@ NODE_ROOT 0..54 {
           }
         }
         TOKEN_WHITESPACE(" ") 46..47
-        TOKEN_IDENT("or") 47..49
+        TOKEN_OR("or") 47..49
         TOKEN_WHITESPACE(" ") 49..50
         NODE_LITERAL 50..51 {
           TOKEN_INTEGER("5") 50..51

--- a/test_data/general/or-as-ident.expect
+++ b/test_data/general/or-as-ident.expect
@@ -1,19 +1,25 @@
-NODE_ROOT 0..132 {
+NODE_ROOT 0..136 {
   TOKEN_COMMENT("# https://github.com/NixOS/nixpkgs/blob/38860c9e91cb00f4d8cd19c7b4e36c45680c89b5/nixos/modules/security/pam.nix#L1180") 0..117
   TOKEN_WHITESPACE("\n") 117..118
-  NODE_APPLY 118..132 {
-    NODE_APPLY 118..126 {
-      NODE_IDENT 118..123 {
-        TOKEN_IDENT("foldl") 118..123
+  NODE_APPLY 118..136 {
+    NODE_APPLY 118..130 {
+      NODE_IDENT 118..121 {
+        TOKEN_IDENT("foo") 118..121
       }
-      TOKEN_WHITESPACE(" ") 123..124
-      NODE_IDENT 124..126 {
-        TOKEN_IDENT("or") 124..126
+      TOKEN_WHITESPACE(" ") 121..122
+      NODE_APPLY 122..130 {
+        NODE_IDENT 122..127 {
+          TOKEN_IDENT("foldl") 122..127
+        }
+        TOKEN_WHITESPACE(" ") 127..128
+        NODE_IDENT 128..130 {
+          TOKEN_IDENT("or") 128..130
+        }
       }
     }
-    TOKEN_WHITESPACE(" ") 126..127
-    NODE_IDENT 127..132 {
-      TOKEN_IDENT("false") 127..132
+    TOKEN_WHITESPACE(" ") 130..131
+    NODE_IDENT 131..136 {
+      TOKEN_IDENT("false") 131..136
     }
   }
 }

--- a/test_data/general/or-as-ident.nix
+++ b/test_data/general/or-as-ident.nix
@@ -1,2 +1,2 @@
 # https://github.com/NixOS/nixpkgs/blob/38860c9e91cb00f4d8cd19c7b4e36c45680c89b5/nixos/modules/security/pam.nix#L1180
-foldl or false
+foo foldl or false

--- a/test_data/parser/ifs/1.expect
+++ b/test_data/parser/ifs/1.expect
@@ -13,7 +13,7 @@ NODE_ROOT 0..33 {
             TOKEN_IDENT("false") 9..14
           }
         }
-        TOKEN_AND("&&") 14..16
+        TOKEN_AND_AND("&&") 14..16
         NODE_BIN_OP 16..27 {
           NODE_IDENT 16..21 {
             TOKEN_IDENT("false") 16..21
@@ -24,7 +24,7 @@ NODE_ROOT 0..33 {
           }
         }
       }
-      TOKEN_OR("||") 27..29
+      TOKEN_OR_OR("||") 27..29
       NODE_IDENT 29..33 {
         TOKEN_IDENT("true") 29..33
       }

--- a/test_data/parser/ifs/2.expect
+++ b/test_data/parser/ifs/2.expect
@@ -9,7 +9,7 @@ NODE_ROOT 0..20 {
         TOKEN_INTEGER("2") 2..3
       }
     }
-    TOKEN_OR("||") 3..5
+    TOKEN_OR_OR("||") 3..5
     NODE_BIN_OP 5..20 {
       NODE_BIN_OP 5..14 {
         NODE_BIN_OP 5..9 {
@@ -21,7 +21,7 @@ NODE_ROOT 0..20 {
             TOKEN_INTEGER("2") 8..9
           }
         }
-        TOKEN_AND("&&") 9..11
+        TOKEN_AND_AND("&&") 9..11
         NODE_BIN_OP 11..14 {
           NODE_LITERAL 11..12 {
             TOKEN_INTEGER("2") 11..12
@@ -32,7 +32,7 @@ NODE_ROOT 0..20 {
           }
         }
       }
-      TOKEN_AND("&&") 14..16
+      TOKEN_AND_AND("&&") 14..16
       NODE_BIN_OP 16..20 {
         NODE_LITERAL 16..17 {
           TOKEN_INTEGER("2") 16..17

--- a/test_data/parser/ifs/3.expect
+++ b/test_data/parser/ifs/3.expect
@@ -9,7 +9,7 @@ NODE_ROOT 0..10 {
         TOKEN_INTEGER("1") 3..4
       }
     }
-    TOKEN_AND("&&") 4..6
+    TOKEN_AND_AND("&&") 4..6
     NODE_BIN_OP 6..10 {
       NODE_LITERAL 6..7 {
         TOKEN_INTEGER("2") 6..7

--- a/test_data/parser/isset/1.expect
+++ b/test_data/parser/isset/1.expect
@@ -13,7 +13,7 @@ NODE_ROOT 0..11 {
         }
       }
     }
-    TOKEN_AND("&&") 5..7
+    TOKEN_AND_AND("&&") 5..7
     NODE_IDENT 7..11 {
       TOKEN_IDENT("true") 7..11
     }

--- a/test_data/parser/isset/2.expect
+++ b/test_data/parser/isset/2.expect
@@ -15,7 +15,7 @@ NODE_ROOT 0..14 {
         }
       }
       TOKEN_WHITESPACE(" ") 5..6
-      TOKEN_IDENT("or") 6..8
+      TOKEN_OR("or") 6..8
       TOKEN_WHITESPACE(" ") 8..9
       NODE_LITERAL 9..10 {
         TOKEN_INTEGER("1") 9..10


### PR DESCRIPTION
### Summary & Motivation

See details in https://github.com/nix-community/rnix-parser/pull/106#issuecomment-1193152913

- Parse "or" as a keyword by default, used as selection with default.
  Eg. `a.b or c`

- When expecting an attribute, accept "or" and make it an identifier.
  Eg. `let or.or = 1; in ...`

- When parsed a primary expression, with not "." following, and the next
  token is "or", it is consumed as an identifier and an application node
  is immediately constructed, ignoring the the associativity of ancestor
  applications.
  Eg. `a b or c` is grouped as `((a (b or)) c)`

- Otherwise, "or" is disallowed.
  Eg. `or 1` will fail.

### Backwards-incompatible changes

- TOKEN_OR -> TOKEN_OR_OR
- TOKEN_AND -> TOKEN_AND_AND

### Further context
