### PR TITLE
Lexer refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -77,9 +74,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
@@ -103,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools",
@@ -113,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -123,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -134,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -148,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -192,9 +189,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -292,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"
@@ -304,9 +301,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -317,15 +314,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
 dependencies = [
  "plotters-backend",
 ]
@@ -374,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "regex-syntax",
 ]
@@ -389,9 +386,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rnix"
@@ -403,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.15.5"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1f383129e417a6265b16ed78e6e9307748f0863b2ba75f78ff14717db5b017"
+checksum = "e88acf7b001007e9e8c989fe7449f6601d909e5dd2c56399fc158977ad6c56e8"
 dependencies = [
  "countme",
  "hashbrown",
@@ -419,15 +416,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "ryu"
@@ -451,16 +439,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
-
-[[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 
 [[package]]
 name = "serde_cbor"
@@ -474,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-width"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,15 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "cbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b6ad25ae296159fb0da12b970b2fe179b234584d7cd294c891e2bbb284466b"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,7 +62,6 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 name = "rnix"
 version = "0.11.0-dev"
 dependencies = [
- "cbitset",
  "rowan",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "rnix-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/rust-toolchain.toml
+++ b/fuzz/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+profile = "minimal"

--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -56,8 +56,6 @@ pub enum SyntaxKind {
     TOKEN_OR_OR,
 
     // Identifiers and values
-    TOKEN_DYNAMIC_END,
-    TOKEN_DYNAMIC_START,
     TOKEN_FLOAT,
     TOKEN_IDENT,
     TOKEN_INTEGER,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -235,7 +235,7 @@ where
     fn parse_dynamic(&mut self) {
         self.start_node(NODE_DYNAMIC);
         self.bump();
-        while self.peek().map(|t| t != TOKEN_DYNAMIC_END).unwrap_or(false) {
+        while self.peek().map(|t| t != TOKEN_INTERPOL_END).unwrap_or(false) {
             self.parse_expr();
         }
         self.bump();
@@ -269,7 +269,7 @@ where
     }
     fn parse_attr(&mut self) {
         match self.peek() {
-            Some(TOKEN_DYNAMIC_START) => self.parse_dynamic(),
+            Some(TOKEN_INTERPOL_START) => self.parse_dynamic(),
             Some(TOKEN_STRING_START) => self.parse_string(),
             _ => self.expect_ident(),
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -317,13 +317,7 @@ impl<'a> Tokenizer<'a> {
                         Some(new) => *extra_brackets = new,
                         None => {
                             self.pop_ctx(Context::Interpol { brackets: 0 });
-                            return {
-                                Some(match self.ctx.last().copied() {
-                                    Some(Context::StringBody { .. }) => TOKEN_INTERPOL_END,
-                                    Some(Context::Path) => TOKEN_INTERPOL_END,
-                                    _ => TOKEN_DYNAMIC_END,
-                                })
-                            };
+                            return Some(TOKEN_INTERPOL_END);
                         }
                     }
                 }
@@ -392,7 +386,7 @@ impl<'a> Tokenizer<'a> {
             '$' if self.peek() == Some('{') => {
                 self.next().unwrap();
                 self.push_ctx(Context::Interpol { brackets: 0 });
-                TOKEN_DYNAMIC_START
+                TOKEN_INTERPOL_START
             }
             'a'..='z' | 'A'..='Z' | '_' => {
                 let kind = match kind {
@@ -1245,9 +1239,9 @@ mod tests {
             tokens![
                 (TOKEN_IDENT, "a"),
                 (TOKEN_DOT, "."),
-                (TOKEN_DYNAMIC_START, "${"),
+                (TOKEN_INTERPOL_START, "${"),
                 (TOKEN_IDENT, "b"),
-                (TOKEN_DYNAMIC_END, "}"),
+                (TOKEN_INTERPOL_END, "}"),
                 (TOKEN_DOT, "."),
                 (TOKEN_IDENT, "c"),
             ]
@@ -1257,7 +1251,7 @@ mod tests {
             tokens![
                 (TOKEN_IDENT, "a"),
                 (TOKEN_DOT, "."),
-                (TOKEN_DYNAMIC_START, "${"),
+                (TOKEN_INTERPOL_START, "${"),
                 (TOKEN_WHITESPACE, " "),
                 (TOKEN_CURLY_B_OPEN, "{"),
                 (TOKEN_WHITESPACE, " "),
@@ -1276,7 +1270,7 @@ mod tests {
                 (TOKEN_DOT, "."),
                 (TOKEN_IDENT, "b"),
                 (TOKEN_WHITESPACE, " "),
-                (TOKEN_DYNAMIC_END, "}"),
+                (TOKEN_INTERPOL_END, "}"),
                 (TOKEN_DOT, "."),
                 (TOKEN_IDENT, "c"),
             ]

--- a/test_data/general/dynamic-attrs.expect
+++ b/test_data/general/dynamic-attrs.expect
@@ -29,11 +29,11 @@ NODE_ROOT 0..216 {
             NODE_ATTRPATH_VALUE 28..42 {
               NODE_ATTRPATH 28..35 {
                 NODE_DYNAMIC 28..35 {
-                  TOKEN_DYNAMIC_START("${") 28..30
+                  TOKEN_INTERPOL_START("${") 28..30
                   NODE_IDENT 30..34 {
                     TOKEN_IDENT("name") 30..34
                   }
-                  TOKEN_DYNAMIC_END("}") 34..35
+                  TOKEN_INTERPOL_END("}") 34..35
                 }
               }
               TOKEN_WHITESPACE(" ") 35..36
@@ -208,11 +208,11 @@ NODE_ROOT 0..216 {
             TOKEN_WHITESPACE(" ") 196..197
             NODE_ATTRPATH 197..211 {
               NODE_DYNAMIC 197..211 {
-                TOKEN_DYNAMIC_START("${") 197..199
+                TOKEN_INTERPOL_START("${") 197..199
                 NODE_IDENT 199..210 {
                   TOKEN_IDENT("dynamic_key") 199..210
                 }
-                TOKEN_DYNAMIC_END("}") 210..211
+                TOKEN_INTERPOL_END("}") 210..211
               }
             }
           }

--- a/test_data/parser/index_set/3.expect
+++ b/test_data/parser/index_set/3.expect
@@ -24,11 +24,11 @@ NODE_ROOT 0..33 {
       }
       TOKEN_DOT(".") 28..29
       NODE_DYNAMIC 29..33 {
-        TOKEN_DYNAMIC_START("${") 29..31
+        TOKEN_INTERPOL_START("${") 29..31
         NODE_IDENT 31..32 {
           TOKEN_IDENT("a") 31..32
         }
-        TOKEN_DYNAMIC_END("}") 32..33
+        TOKEN_INTERPOL_END("}") 32..33
       }
     }
   }

--- a/test_data/parser/inherit/1.expect
+++ b/test_data/parser/inherit/1.expect
@@ -50,13 +50,13 @@ NODE_ROOT 0..95 {
       TOKEN_INHERIT("inherit") 36..43
       TOKEN_WHITESPACE(" ") 43..44
       NODE_DYNAMIC 44..50 {
-        TOKEN_DYNAMIC_START("${") 44..46
+        TOKEN_INTERPOL_START("${") 44..46
         NODE_STRING 46..49 {
           TOKEN_STRING_START("\"") 46..47
           TOKEN_STRING_CONTENT("f") 47..48
           TOKEN_STRING_END("\"") 48..49
         }
-        TOKEN_DYNAMIC_END("}") 49..50
+        TOKEN_INTERPOL_END("}") 49..50
       }
       TOKEN_SEMICOLON(";") 50..51
     }

--- a/test_data/parser/isset/multiple.expect
+++ b/test_data/parser/isset/multiple.expect
@@ -19,13 +19,13 @@ NODE_ROOT 0..15 {
     TOKEN_WHITESPACE(" ") 8..9
     NODE_ATTRPATH 9..15 {
       NODE_DYNAMIC 9..15 {
-        TOKEN_DYNAMIC_START("${") 9..11
+        TOKEN_INTERPOL_START("${") 9..11
         NODE_STRING 11..14 {
           TOKEN_STRING_START("\"") 11..12
           TOKEN_STRING_CONTENT("a") 12..13
           TOKEN_STRING_END("\"") 13..14
         }
-        TOKEN_DYNAMIC_END("}") 14..15
+        TOKEN_INTERPOL_END("}") 14..15
       }
     }
   }

--- a/test_data/parser/paths/4.expect
+++ b/test_data/parser/paths/4.expect
@@ -4,9 +4,9 @@ NODE_ROOT 0..7 {
     TOKEN_IDENT("a") 0..1
   }
   NODE_ERROR 1..7 {
-    TOKEN_DYNAMIC_START("${") 1..3
+    TOKEN_INTERPOL_START("${") 1..3
     TOKEN_IDENT("b") 3..4
-    TOKEN_DYNAMIC_END("}") 4..5
+    TOKEN_INTERPOL_END("}") 4..5
     TOKEN_PATH("/c") 5..7
   }
 }

--- a/test_data/parser/set/4.expect
+++ b/test_data/parser/set/4.expect
@@ -36,11 +36,11 @@ NODE_ROOT 0..33 {
         }
         TOKEN_DOT(".") 21..22
         NODE_DYNAMIC 22..26 {
-          TOKEN_DYNAMIC_START("${") 22..24
+          TOKEN_INTERPOL_START("${") 22..24
           NODE_IDENT 24..25 {
             TOKEN_IDENT("d") 24..25
           }
-          TOKEN_DYNAMIC_END("}") 25..26
+          TOKEN_INTERPOL_END("}") 25..26
         }
       }
       TOKEN_WHITESPACE(" ") 26..27


### PR DESCRIPTION
### Summary & Motivation

Fixes error introduced in #102 because we weren't checking for `None`. Refactors the lexer to use the context only instead of duplicating it in struct fields. Make  tests cleaner and shorter by removing `tokens` macro. 