### PR TITLE
Add getters for typed Dynamic parts

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -231,6 +231,12 @@ impl Attrpath {
 
 node! { #[from(NODE_DYNAMIC)] struct Dynamic; }
 
+impl Dynamic {
+    tg! { interpol_start_token, TOKEN_INTERPOL_START }
+    ng! { expr, Expr, 0 }
+    tg! { interpol_end_token, TOKEN_INTERPOL_END }
+}
+
 node! { #[from(NODE_ERROR)] struct Error; }
 
 node! { #[from(NODE_IF_ELSE)] struct IfElse; }


### PR DESCRIPTION
### Summary & Motivation
Add missing impl for typed `Dynamic` node, primarily to get access to the inner expression.

I opted to write `TOKEN_INTERPOL_START` and `TOKEN_INTERPOL_END` directly instead of adding cases to the `T` macro, because the latter overlaps with `TOKEN_CURLY_B_CLOSE`.