### PR TITLE
Remove Expr Inherit and InheritFrom variants

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -172,8 +172,6 @@ node! {
         NODE_ERROR => Error,
         NODE_IF_ELSE => IfElse,
         NODE_SELECT => Select,
-        NODE_INHERIT => Inherit,
-        NODE_INHERIT_FROM => InheritFrom,
         NODE_STRING => Str,
         NODE_PATH => Path,
         NODE_LITERAL => Literal,


### PR DESCRIPTION
### Summary & Motivation
Removes Inherit and InheritFrom variants from the typed Expr enum

### Backwards-incompatible changes
Removed `ast::Expr::Inherit` and `ast::Expr::InheritFrom`

### Further context
Fixes #125 

There might be some reason that I'm missing for why these should be `Expr`s.
