### PR TITLE
Export LiteralKind from ast

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,6 +8,7 @@ mod tokens;
 
 use crate::{NixLanguage, SyntaxKind, SyntaxToken};
 
+pub use expr_ext::LiteralKind;
 pub use nodes::*;
 pub use operators::{BinOpKind, UnaryOpKind};
 pub use str_util::StrPart;


### PR DESCRIPTION
### Summary & Motivation
Re-export `LiteralKind` from `ast`. I don't think it is possible to use currently. 