### PR TITLE
Wrap pat entry ident in NODE_IDENT

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,7 +320,7 @@ where
                     }
                     Some(TOKEN_IDENT) => {
                         self.start_node(NODE_PAT_ENTRY);
-                        self.bump();
+                        self.expect_ident();
                         if let Some(T![?]) = self.peek() {
                             self.bump();
                             self.parse_expr();

--- a/test_data/parser/success/pattern_bind_left.expect
+++ b/test_data/parser/success/pattern_bind_left.expect
@@ -10,7 +10,8 @@ NODE_ROOT@0..20
       TOKEN_L_BRACE@8..9 "{"
       TOKEN_WHITESPACE@9..10 " "
       NODE_PAT_ENTRY@10..11
-        TOKEN_IDENT@10..11 "a"
+        NODE_IDENT@10..11
+          TOKEN_IDENT@10..11 "a"
       TOKEN_WHITESPACE@11..12 " "
       TOKEN_R_BRACE@12..13 "}"
     TOKEN_COLON@13..14 ":"

--- a/test_data/parser/success/pattern_default.expect
+++ b/test_data/parser/success/pattern_default.expect
@@ -4,11 +4,13 @@ NODE_ROOT@0..23
       TOKEN_L_BRACE@0..1 "{"
       TOKEN_WHITESPACE@1..2 " "
       NODE_PAT_ENTRY@2..3
-        TOKEN_IDENT@2..3 "a"
+        NODE_IDENT@2..3
+          TOKEN_IDENT@2..3 "a"
       TOKEN_COMMA@3..4 ","
       TOKEN_WHITESPACE@4..5 " "
       NODE_PAT_ENTRY@5..18
-        TOKEN_IDENT@5..6 "b"
+        NODE_IDENT@5..6
+          TOKEN_IDENT@5..6 "b"
         TOKEN_WHITESPACE@6..7 " "
         TOKEN_QUESTION@7..8 "?"
         TOKEN_WHITESPACE@8..9 " "

--- a/test_data/parser/success/pattern_default_attrset.expect
+++ b/test_data/parser/success/pattern_default_attrset.expect
@@ -3,7 +3,8 @@ NODE_ROOT@0..8
     NODE_PATTERN@0..6
       TOKEN_L_BRACE@0..1 "{"
       NODE_PAT_ENTRY@1..5
-        TOKEN_IDENT@1..2 "a"
+        NODE_IDENT@1..2
+          TOKEN_IDENT@1..2 "a"
         TOKEN_QUESTION@2..3 "?"
         NODE_ATTR_SET@3..5
           TOKEN_L_BRACE@3..4 "{"

--- a/test_data/parser/success/pattern_default_ellipsis.expect
+++ b/test_data/parser/success/pattern_default_ellipsis.expect
@@ -4,11 +4,13 @@ NODE_ROOT@0..28
       TOKEN_L_BRACE@0..1 "{"
       TOKEN_WHITESPACE@1..2 " "
       NODE_PAT_ENTRY@2..3
-        TOKEN_IDENT@2..3 "a"
+        NODE_IDENT@2..3
+          TOKEN_IDENT@2..3 "a"
       TOKEN_COMMA@3..4 ","
       TOKEN_WHITESPACE@4..5 " "
       NODE_PAT_ENTRY@5..18
-        TOKEN_IDENT@5..6 "b"
+        NODE_IDENT@5..6
+          TOKEN_IDENT@5..6 "b"
         TOKEN_WHITESPACE@6..7 " "
         TOKEN_QUESTION@7..8 "?"
         TOKEN_WHITESPACE@8..9 " "

--- a/test_data/parser/success/pattern_trailing_comma.expect
+++ b/test_data/parser/success/pattern_trailing_comma.expect
@@ -3,7 +3,8 @@ NODE_ROOT@0..6
     NODE_PATTERN@0..4
       TOKEN_L_BRACE@0..1 "{"
       NODE_PAT_ENTRY@1..2
-        TOKEN_IDENT@1..2 "a"
+        NODE_IDENT@1..2
+          TOKEN_IDENT@1..2 "a"
       TOKEN_COMMA@2..3 ","
       TOKEN_R_BRACE@3..4 "}"
     TOKEN_COLON@4..5 ":"


### PR DESCRIPTION
Fixes getting the ident from a PatEntry here:
https://github.com/nix-community/rnix-parser/blob/f8056c4811b6f5196af64db14b89651e892ad98a/src/ast/nodes.rs#L356-L357