### PR TITLE
change Inherit::idents to Inherit::attrs

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -268,7 +268,7 @@ node! { #[from(NODE_INHERIT)] struct Inherit; }
 impl Inherit {
     tg! { inherit_token, inherit }
     ng! { from, InheritFrom, 0 }
-    ng! { idents, [Ident] }
+    ng! { attrs, [Attr] }
 }
 
 node! { #[from(NODE_INHERIT_FROM)] struct InheritFrom; }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,7 +45,7 @@ fn inherit() {
     let from = inherit.from().unwrap().expr().unwrap();
     let ident: ast::Ident = ast::Ident::try_from(from).unwrap();
     assert_eq!(ident.syntax().text(), "set");
-    let mut children = inherit.idents();
+    let mut children = inherit.attrs();
     assert_eq!(children.next().unwrap().syntax().text(), "z");
     assert_eq!(children.next().unwrap().syntax().text(), "a");
     assert!(children.next().is_none());


### PR DESCRIPTION
`idents` returns all the identifiers in the `InheritFrom`, but the correct thing to return is all the `Attr`.

https://github.com/NixOS/nix/blob/master/src/libexpr/parser.y#L542