### PR TITLE
pretty print ast for from-stdin example

### DIFF
--- a/examples/from-stdin.rs
+++ b/examples/from-stdin.rs
@@ -9,5 +9,5 @@ fn main() {
         println!("error: {}", error);
     }
 
-    println!("{}", ast.tree());
+    println!("{:#?}", ast.tree());
 }


### PR DESCRIPTION
It's not that useful to exact print what is passed from stdin.