### PR TITLE
SyntaxKind::is_literal(): update to match usage

### DIFF
--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -106,9 +106,9 @@ pub enum SyntaxKind {
 use SyntaxKind::*;
 
 impl SyntaxKind {
-    /// Returns true if this token is a literal, such as an integer or a string
+    /// Returns true if this token is parsed into a NODE_LITERAL
     pub fn is_literal(self) -> bool {
-        matches!(self, TOKEN_FLOAT | TOKEN_INTEGER | TOKEN_PATH | TOKEN_URI)
+        matches!(self, TOKEN_FLOAT | TOKEN_INTEGER | TOKEN_URI)
     }
 
     /// Returns true if this token should be used as a function argument.
@@ -124,6 +124,7 @@ impl SyntaxKind {
     pub fn is_fn_arg(self) -> bool {
         match self {
             TOKEN_REC | TOKEN_L_BRACE | TOKEN_L_BRACK | TOKEN_L_PAREN | TOKEN_STRING_START
+            | TOKEN_PATH
             | TOKEN_IDENT => true,
             _ => self.is_literal(),
         }


### PR DESCRIPTION
### Summary & Motivation

`SyntaxKind::is_literal()`'s comment says that it "Returns true if this token is a literal, such as an integer or a string", but this isn't true -- it doesn't return `true` for string literals.

After examining how `is_literal()` is used, the fact that it returns true for path literals ~~is unused.~~ is barely used.

It appears that the intent of this function was to return `true` if `parser.rs` will parse the specified `TokenKind` into a `NODE_LITERAL`.  Let's update the comment to indicate this, and then adjust the implementation to agree with the comment.

### Backwards-incompatible changes

`NODE_PATH::is_literal()` now returns `false`.

Downstream which depended on the previous behavior was not likely getting the results they expected.

### Further context

Noticed due to https://cl.tvl.fyi/c/depot/+/7030/