### PR TITLE
Bumped library version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "rnix"
 readme = "README.md"
 repository = "https://github.com/nix-community/rnix-parser"
-version = "0.11.1"
+version = "0.12.0"
 
 [[bench]]
 harness = false


### PR DESCRIPTION
I realized my previous PR needed a semver bump, since it added variants to a public enum which is a breaking change (users' match statements could become non-exhaustive and error).