### PR TITLE
feat: add Root::parse_bytes for non-UTF8 input

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -132,15 +132,11 @@ fn tokenizer_dir_tests() {
 #[allow(invalid_from_utf8)]
 fn non_utf8_can_be_parsed_with_parse_bytes_issue173() {
     // This is `{ x = "\xff"; }` with a raw 0xFF byte (invalid UTF-8) in the string
-    let non_utf8_bytes: &[u8] = &[
-        0x7b, 0x20, 0x78, 0x20, 0x3d, 0x20, 0x22, 0xff, 0x22, 0x3b, 0x20, 0x7d,
-    ];
+    let non_utf8_bytes: &[u8] =
+        &[0x7b, 0x20, 0x78, 0x20, 0x3d, 0x20, 0x22, 0xff, 0x22, 0x3b, 0x20, 0x7d];
 
     // Verify this is indeed invalid UTF-8
-    assert!(
-        std::str::from_utf8(non_utf8_bytes).is_err(),
-        "test input should be invalid UTF-8"
-    );
+    assert!(std::str::from_utf8(non_utf8_bytes).is_err(), "test input should be invalid UTF-8");
 
     // parse_bytes handles non-UTF8 by doing lossy conversion
     let parse = Root::parse_bytes(non_utf8_bytes);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -125,3 +125,25 @@ fn tokenizer_dir_tests() {
         actual
     })
 }
+
+/// Test that demonstrates the non-UTF8 limitation (issue #173).
+/// nix (C++) can parse files with non-UTF8 bytes, but rnix requires valid UTF-8.
+#[test]
+#[allow(invalid_from_utf8)]
+fn non_utf8_cannot_be_parsed_issue173() {
+    // This is `{ x = "\xff"; }` with a raw 0xFF byte (invalid UTF-8) in the string
+    let non_utf8_bytes: &[u8] = &[
+        0x7b, 0x20, 0x78, 0x20, 0x3d, 0x20, 0x22, 0xff, 0x22, 0x3b, 0x20, 0x7d,
+    ];
+
+    // Verify this is indeed invalid UTF-8
+    assert!(
+        std::str::from_utf8(non_utf8_bytes).is_err(),
+        "test input should be invalid UTF-8"
+    );
+
+    // Currently, rnix cannot parse this because Root::parse requires &str.
+    // This test documents the limitation described in issue #173.
+    // When this issue is fixed, this test should be updated to verify
+    // that parsing succeeds with a bytes-based API.
+}


### PR DESCRIPTION
## Summary

- Add `Root::parse_bytes(&[u8])` method that handles non-UTF8 input
- Invalid UTF-8 sequences are replaced with U+FFFD (replacement character)

## Background

The C++ Nix parser uses [`%option 8bit`](https://github.com/NixOS/nix/blob/master/src/libexpr/lexer.l#L1) in its flex lexer, which allows it to handle arbitrary byte values without UTF-8 validation. The raw bytes are preserved in string literals.

rnix uses [Rowan](https://github.com/rust-analyzer/rowan) for its syntax tree, which requires valid UTF-8. This means we cannot preserve arbitrary bytes exactly. Instead, `parse_bytes` does lossy UTF-8 conversion - invalid sequences become U+FFFD (�).

**Behavior comparison:**
| Input bytes | nix output | rnix parse_bytes output |
|-------------|------------|-------------------------|
| `{ x = "\xff"; }` | `{ x = "\xff"; }` (raw 0xFF preserved) | `{ x = "�"; }` (U+FFFD replacement) |

This is sufficient for most use cases (linting, formatting, analysis) where exact byte preservation isn't required.

## Example

```rust
// { x = "\xff"; } with raw 0xFF byte (invalid UTF-8)
let bytes: &[u8] = &[0x7b, 0x20, 0x78, 0x20, 0x3d, 0x20, 0x22, 0xff, 0x22, 0x3b, 0x20, 0x7d];
let parse = Root::parse_bytes(bytes);
assert!(parse.errors().is_empty());
// Output text: { x = "�"; }
```

## Test plan

- [x] Added test case `non_utf8_can_be_parsed_with_parse_bytes_issue173`
- [x] All existing tests pass

Closes #173