### PR TITLE
Implement path lookahead and optimize normalization

### DIFF
--- a/benches/all-packages.rs
+++ b/benches/all-packages.rs
@@ -1,4 +1,7 @@
+use std::hint::black_box;
+
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use rowan::ast::AstNode;
 
 fn all_packages(c: &mut Criterion) {
     let input = include_str!("all-packages.nix");
@@ -11,5 +14,34 @@ fn all_packages(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, all_packages);
+fn tokenizer(c: &mut Criterion) {
+    let input = include_str!("all-packages.nix");
+    let mut group = c.benchmark_group("tokenizer");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    group.sample_size(30);
+    group.bench_with_input("all-packages", input, |b, input| {
+        b.iter(|| rnix::tokenize(black_box(input)).count())
+    });
+    group.finish();
+}
+
+fn normalized_parts(c: &mut Criterion) {
+    let input = include_str!("all-packages.nix");
+    let parse = rnix::Root::parse(input);
+    let strings = parse.syntax().descendants().filter_map(rnix::ast::Str::cast).collect::<Vec<_>>();
+    assert!(!strings.is_empty());
+
+    let mut group = c.benchmark_group("normalized-parts");
+    group.sample_size(30);
+    group.bench_function("all-packages", |b| {
+        b.iter(|| {
+            for string in &strings {
+                black_box(string.normalized_parts());
+            }
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, all_packages, tokenizer, normalized_parts);
 criterion_main!(benches);

--- a/src/ast/str_util.rs
+++ b/src/ast/str_util.rs
@@ -31,10 +31,8 @@ impl ast::Str {
         let mut n = 0;
         let mut first_is_literal = false;
 
-        let parts: Vec<InterpolPart<StrContent>> = self.parts().collect();
-
         if multiline {
-            for part in &parts {
+            for part in self.parts() {
                 match part {
                     InterpolPart::Interpolation(_) => {
                         if at_start_of_line {
@@ -81,13 +79,14 @@ impl ast::Str {
             }
         }
 
-        let mut normalized_parts = Vec::new();
+        let mut normalized_parts =
+            Vec::with_capacity(if multiline { n } else { self.parts().count() });
         let mut cur_dropped = 0;
         let mut i = 0;
         is_first_literal = true;
         at_start_of_line = true;
 
-        for part in parts {
+        for part in self.parts() {
             match part {
                 InterpolPart::Interpolation(interpol) => {
                     at_start_of_line = false;
@@ -112,7 +111,7 @@ impl ast::Str {
                             }
                         }
 
-                        let mut str = String::new();
+                        let mut str = String::with_capacity(token_text.len());
                         for c in token_text.chars() {
                             if at_start_of_line {
                                 if c == ' ' {
@@ -160,7 +159,7 @@ impl ast::Str {
 
 /// Interpret escape sequences in the nix string and return the converted value
 pub fn unescape(input: &str, multiline: bool) -> String {
-    let mut output = String::new();
+    let mut output = String::with_capacity(input.len());
     let mut input = input.chars().peekable();
     loop {
         match input.next() {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -307,16 +307,18 @@ impl Tokenizer<'_> {
         } else {
             // Fallback to heuristic previously used for relative, search and URI paths.
             let store_path = self.peek() == Some('<');
-            let skipped = self
-                .remaining()
-                .chars()
-                .take_while(|&c| match c {
+            let remaining = self.remaining();
+            let (skipped_len, contains_underscore) = remaining
+                .char_indices()
+                .take_while(|&(_, c)| match c {
                     '<' | '/' => store_path,
                     _ => is_valid_path_char(c),
                 })
-                .collect::<String>();
+                .fold((0, false), |(_, contains_underscore), (offset, c)| {
+                    (offset + c.len_utf8(), contains_underscore || c == '_')
+                });
 
-            let mut lookahead = self.remaining().chars().skip(skipped.chars().count());
+            let mut lookahead = remaining[skipped_len..].chars();
 
             match (lookahead.next(), lookahead.next()) {
                 // a//b parses as Update(a, b)
@@ -328,7 +330,7 @@ impl Tokenizer<'_> {
                     Some(IdentType::PathRel)
                 }
                 (Some('>'), _) => Some(IdentType::PathSearch),
-                (Some(':'), Some(c)) if is_valid_uri_char(c) && !skipped.contains('_') => {
+                (Some(':'), Some(c)) if is_valid_uri_char(c) && !contains_underscore => {
                     Some(IdentType::Uri)
                 }
                 _ => None,


### PR DESCRIPTION
I've gotten really into parser development recently (for the purposes of witing a nftables parser) and ultimately ended up needing/wanting/dreaming of one for Nix. While looking for inspiration in rnix's codebase I've identified some areas that I could be "optimized". If my math is correct, they return rather positive results:

| Bench                                                                |    Before |    After |  Change |
| ------------------------------------------------------------------------ | --------: | -------: | ------: |
| `tokenizer/all-packages`                                                 |  25.45 ms |  6.02 ms | -76.14% |
| `normalized-parts/all-packages`                                          | 300.83 µs | 86.65 µs | -77.62% |

My motivation for the change is rather simple. The way I see it, our path/URI disambiguation code scans an initial run of path characters before it knows what kind of token it is looking at. That scan used to be materialized as a `String`, despite the following decision only needing two things from it:

1. where the scan ended, and
2. whether the prefix contained an underscore

Recording those while scanning keeps the existing classification rules without allocating or walking the prefix again. Thus, this PR removes the temporary `String` allocation, and lookahead now records the byte offset and whether it saw an underscore while scanning the input. On a similar optimization now (which is minor in comparison `Str::normalized_parts` no longer collects all string parts before processing them but instead, it makes separate passes over the immutable syntax tree for indentation detection and output generation, and preallocates the result buffers for us. On rnix's own fixtures, tokenizer time dropped from about 25.5 ms to 6.0 ms, and string normalization dropped from about 301 µs to 87 µs. Which I see as an absolute win even though the numbers are rather small.

I've went back in the git history to see if this changes are intentional by any chance and looks like the temporary `String` dates to all the way back tothe original 2019 URI heuristic. Admittedly it was a straightforward way to retain both "how far did I scan?" and "did I see `_`?" but I think we can do better.

The public API remains the same; the optimization is internal, but I do want to state that `unescape` now reserves `input.len()` even when an escape-heavy string will shrink substantially. This can, in theory, reserve more transient memory for a huge, escape-dense string than the old growth strategy. Should *probably* not matter for most cases.

---

I've written a tiny benchmark suite to get the numbers. I'm keeping this PR as a draft while I beat it into shape, but in the meantime please do feel free to tear apart my changes. I've written this most of those changes while rather exhausted and mostly with the goal of getting them off my mind before I call it a day. If I misread anything or misunderstood any intent anywhere, please let me know. I'm happy to iterate.

P.S. I'm sorry for the wall of text. I do hope this doesn't defer from reviewing the actual change, as it's very simple in theory and in application. I like typing a bit too much.